### PR TITLE
Include preprocess step; remove padding hacks and other data loaders …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Step 3: Preprocess data. This generates files ready to be read by `data/SPRSound
 
 ```shell
 cd data/SPRSound/
-python preprocess.py
+python preprocess.py # this should populate the data/SPRSound/processed/ folder
 ```
 
 Step 4: Take a look at `config_task21.json` first and run the following. This will train a basic model for Task 2-1.

--- a/data/SPRSound/Datasets.py
+++ b/data/SPRSound/Datasets.py
@@ -1,78 +1,25 @@
 from os.path import join
 from torch.utils.data import Dataset
-from torchaudio import load
 import pandas as pd
-
-class Resp11Dataset(Dataset):
-    def __init__(self, data_dir):
-        self.csv = pd.read_csv(join(data_dir, 'task1.csv'))
-        self.audio_dir = join(data_dir, 'wav')
-
-    def __len__(self):
-        return len(self.csv)
-
-    def __getitem__(self, index):
-        entry = self.csv.iloc[index]
-        wav_name = entry['wav_name']
-        audio_sample_path = join(self.audio_dir, wav_name)
-        wav, _ = load(audio_sample_path)
-        target = entry['label_11']
-        return wav, target
-
-
-class Resp12Dataset(Dataset):
-    def __init__(self, data_dir):
-        self.csv = pd.read_csv(join(data_dir, 'task2.csv'))
-        self.audio_dir = join(data_dir, 'wav')
-
-    def __len__(self):
-        return len(self.csv)
-
-    def __getitem__(self, index):
-        entry = self.csv.iloc[index]
-        wav_name = entry['wav_name']
-        audio_sample_path = join(self.audio_dir, wav_name)
-        wav, _ = load(audio_sample_path)
-        target = entry['label_12']
-        return wav, target
-
+import torch
 
 class Resp21Dataset(Dataset):
     def __init__(self, data_dir):
         self.csv = pd.read_csv(join(data_dir, 'task2.csv'))
-        self.audio_dir = join(data_dir, 'wav')
+        self.audio_dir = join(data_dir, 'processed')
 
     def __len__(self):
         return len(self.csv)
 
     def __getitem__(self, index):
         entry = self.csv.iloc[index]
-        wav_name = entry['wav_name']
-        audio_sample_path = join(self.audio_dir, wav_name)
-        wav, _ = load(audio_sample_path)
-        target = entry['label_21']
-        return wav, target
-
-class Resp22Dataset(Dataset):
-    def __init__(self, data_dir):
-        self.csv = pd.read_csv(join(data_dir, 'task2.csv'))
-        self.audio_dir = join(data_dir, 'wav')
-
-    def __len__(self):
-        return len(self.csv)
-
-    def __getitem__(self, index):
-        entry = self.csv.iloc[index]
-        wav_name = entry['wav_name']
-        audio_sample_path = join(self.audio_dir, wav_name)
-        wav, _ = load(audio_sample_path)
-        target = entry['label_22']
+        wav_name, target = entry['wav_name'], entry['label_21']
+        wav = torch.load(join(self.audio_dir, wav_name))
         return wav, target
 
 if __name__ == "__main__":
     r21 = Resp21Dataset('.')
     print(f"There are {len(r21)} samples in the dataset.")
-    wav, _, target = r21[0]
+    wav, target = r21[0]
     print(target)
-    print(wav.shape)  # max length 122880
-    
+    print(wav.shape)

--- a/data/SPRSound/preprocess.py
+++ b/data/SPRSound/preprocess.py
@@ -1,20 +1,45 @@
+"""
+The `preprocess` function will be exported to main.py
+"""
+
 from os import listdir
 from os.path import join
 from torchaudio import load
+import torch
+import librosa
+from tqdm import tqdm
 
-WAV_DIR = "wav"
-CLIP_DIR = "clip"
-PROC_DIR = "processed"
+def normalize(x):
+    maximum = torch.max(x, dim=-1, keepdim=True)[0]
+    minimum = torch.min(x, dim=-1, keepdim=True)[0]
+    return (x-minimum) / (maximum - minimum)
 
 def preprocess(wav):
     """
-    This function will be exported to main.py
+    Input: torch.Tensor of torch.Size([1, N]), where N is total number frames
+    Output: torch.Tensor of size torch.Size([200])
     """
-    processed = wav
-    # TODO
-    # could be a image
+    wav = normalize(wav)
+    wav = torch.squeeze(wav)
+    # librosa uses np.ndarry exclusively
+    wav = wav.cpu().detach().numpy()
+    n_fft = 2048
+    ft = librosa.stft(wav[:n_fft], hop_length=n_fft+1)
+    ft = ft[:200]
+    # convert back to torch.Tensor
+    processed = torch.from_numpy(ft)
+    processed = torch.abs(processed)
+    processed = torch.squeeze(processed)
     return processed
 
 if __name__ == '__main__':
+    WAV_DIR = "wav"
+    CLIP_DIR = "clip"
+    PROC_DIR = "processed"
 
-    print('todo.')
+    for wav_name in tqdm(listdir(WAV_DIR)):
+        wav, _ = load(join(WAV_DIR, wav_name))
+        processed = preprocess(wav)
+        torch.save(processed, join(PROC_DIR, wav_name))
+        # print(processed.shape)
+        # break

--- a/model/model.py
+++ b/model/model.py
@@ -5,8 +5,7 @@ from base import BaseModel
 class Resp21Model(BaseModel):
     def __init__(self):
         super().__init__()
-        self.fc = nn.Linear(122880, 3)
-        # TODO
+        self.fc = nn.Linear(200, 3)
 
     def forward(self, x):
         return self.fc(x)


### PR DESCRIPTION
…for now

This PR is intended to reduce friction in adding preprocessing code. Run `preprocess.py` as main and it will save processed inputs as `torch.Tensor` in the `processed` folder, which will then be read by `Datasets.py` (and `Dataloader.py`).

A minimal network is used for demonstration purpose. 

Check out the "Files changed" tab above to see all edits.